### PR TITLE
Update governance.md

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -7,7 +7,7 @@ The CSL project wishes to facilitate the advancement of science and scholarship 
 ## Communication
 The [Discourse CSL forum](https://discourse.citationstyles.org/) is our “public square”, and the central place for announcements, deliberation, and decision-making for all things related to CSL. While minor decisions may be made directly in our GitHub repositories, significant decisions should always either be discussed or highlighted on the forum.
 
-We wish the CSL project to be welcoming to all, and have adopted the [Contributor Covenant](https://www.contributor-covenant.org/) for our [Code of Conduct](https://github.com/citation-style-language/.github/blob/master/CODE_OF_CONDUCT.md).
+The CSL project welcomes all and has adopted adopted the [Contributor Covenant](https://www.contributor-covenant.org/) for our [Code of Conduct](https://github.com/citation-style-language/.github/blob/master/CODE_OF_CONDUCT.md).
 
 ## Board
 The role of the board members is to shepherd the development and maintenance of the CSL in accordance with the project mission, and to allocate any funds made available to this purpose.

--- a/governance.md
+++ b/governance.md
@@ -5,7 +5,9 @@ This document defines the mission of the Citation Style Language (CSL) project a
 The CSL project wishes to facilitate the advancement of science and scholarship by automating the correct formatting of citations. We hope to save researchers time and help improve the quality of scholarly literature. To this end, we will continue to develop the CSL specification and maintain the CSL citation style and locale file repositories. We promise to keep CSL free and open source. We will aim to maximize CSL's interoperability and reusability, and encourage its use in new contexts.
 
 ## Communication
-The [xbiblio-devel mailing list](https://lists.sourceforge.net/lists/listinfo/xbiblio-devel) is our “public square”, and the central place for announcements, deliberation, and decision-making for all things related to CSL. Anyone may join the mailing list, and its [archives](http://xbiblio-devel.2463403.n2.nabble.com/) will always be publically available.
+The [Discourse CSL forum](https://discourse.citationstyles.org/) is our “public square”, and the central place for announcements, deliberation, and decision-making for all things related to CSL. While minor decisions may be made directly in our GitHub repositories, significant decisions should always either be discussed or highlighted on the forum.
+
+We wish the CSL project to be welcoming to all, and have adopted the [Contributor Covenant](https://www.contributor-covenant.org/) for our [Code of Conduct](https://github.com/citation-style-language/.github/blob/master/CODE_OF_CONDUCT.md).
 
 ## Board
 The role of the board members is to shepherd the development and maintenance of the CSL in accordance with the project mission, and to allocate any funds made available to this purpose.


### PR DESCRIPTION
Per https://github.com/citation-style-language/.github/pull/1.

Mentions our new Code of Conduct, and updated to reflect our migration from the xbiblio-dev mailing list to our Discourse forum.